### PR TITLE
passes the user as an obj vs an array

### DIFF
--- a/api/services/auth.js
+++ b/api/services/auth.js
@@ -19,7 +19,7 @@ module.exports = {
                     });
                 } else {
 
-                    var token = jwt.sign(user, sails.config.secret, {expiresIn: 60 * 24});
+                    var token = jwt.sign(user[0], sails.config.secret, {expiresIn: 60 * 24});
                     // Set persistent cookie
                     req.session.cookie.token = token;
                     res.send({


### PR DESCRIPTION
user when passed to the sign function as an array returns an error. 
